### PR TITLE
Add UCSBOrganization entity, repository, and migration files to create database

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author: pgunhal
+ * This is a JPA entity that represents a UCSBOrganization, a student organization at UCSB.  It is used to store the results from the UCSB API for student organizations.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganizations")
+public class UCSBOrganization {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private String orgCode;
+
+  private String orgTranslationShort;
+  private String orgTranslation;
+  private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/** 
+ * @author: pgunhal
+ * The UCSBOrganizationRepository is a repository for UCSBOrganization entities */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -5,9 +5,9 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
-/** 
- * @author: pgunhal
- * The UCSBOrganizationRepository is a repository for UCSBOrganization entities */
+/**
+ * @author: pgunhal The UCSBOrganizationRepository is a repository for UCSBOrganization entities
+ */
 @Repository
 @RepositoryRestResource(exported = false)
 public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {}

--- a/src/main/resources/db/migration/changes/UCSBOrganizations.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganizations.json
@@ -1,0 +1,62 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "UCSBOrganizations",
+          "author": "pgunhal",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBORGANIZATIONS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "ORGANIZATIONS_PK"
+                      },
+                      "name": "ORGCODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ORGTRANSLATIONSHORT",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                   {
+                    "column": {
+                      "name": "ORGTRANSLATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "INACTIVE",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "UCSBORGANIZATIONS"
+              }
+            }]
+
+        }
+    }
+]}


### PR DESCRIPTION
This PR adds backend database support for UCSB Organizations by creating the `UCSBOrganization` entity, its repository, and the Liquibase migration that creates the table.

This closes Issue #14 

## What changed 
- added `UCSBOrganization.java`
- added `UCSBOrganizationRepository.java`
- added database migration file `UCSBOrganization.json`

## Why
This is the first backend step for CRUD support for UCSB Organizations. It creates the database table and persistence layer needed for later controller and test work.

## Testing

### Local
1. Run the app locally with Spring Boot
2. Open the H2 console and log in 
3. Verify that the `UCSBORGANIZATIONS` table appears

### Dokku
1. Deploy the branch to the personal Dokku dev app
2. Connect to the linked Postgres database: with the command:
   dokku postgres:connect team01-pgunhal-db
