### PR TITLE
jw - create database table for menuitemreviews

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** This is a JPA entity that represents a MenuItemReview */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "menuitemreviews")
+public class MenuItemReview {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private long itemId;
+  private String reviewerEmail;
+  private int stars;
+  private LocalDateTime dateReviewed;
+  private String comments;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/** The MenuItemReviewRepository is a repository for MenuItemReview entities. */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long> {}

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -1,0 +1,74 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "MenuItemReviews-1",
+          "author": "Joaquin-Wong",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "MENUITEMREVIEWS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "MENUITEMREVIEWS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ITEM_ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REVIEWER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STARS",
+                      "type": "INT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REVIEWED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COMMENTS",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "MENUITEMREVIEWS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #26 

In this PR we created a database table for menuitemreviews with fields:

```
  private long id;
  private long itemId;
  private String reviewerEmail;
  private int stars;
  private LocalDateTime dateReviewed;
  private String comments;
```
On H2:
<img width="1300" height="810" alt="image" src="https://github.com/user-attachments/assets/2480c27b-9b86-4257-9cdc-b9130d6e1acb" />

On Dokku:
<img width="738" height="416" alt="image" src="https://github.com/user-attachments/assets/70e6423e-3aec-4c4b-b291-8d94ae4be0db" />
