### PR TITLE
Create controller with GET and POST endpoints to MenuItemReview Table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,0 +1,84 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for MenuItemReviews */
+@Tag(name = "MenuItemReviews")
+@RequestMapping("/api/menuitemreviews")
+@RestController
+@Slf4j
+public class MenuItemReviewController extends ApiController {
+
+  @Autowired MenuItemReviewRepository menuItemReviewRepository;
+
+  /**
+   * List all MenuItemReviews
+   *
+   * @return an iterable of MenuItemReview
+   */
+  @Operation(summary = "List all menuitemreviews")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<MenuItemReview> allMenuItemReviews() {
+    Iterable<MenuItemReview> menuitemreviews = menuItemReviewRepository.findAll();
+    return menuitemreviews;
+  }
+
+  /**
+   * Create a new MenuItemReview
+   *
+   * @param itemId id of review
+   * @param reviewerEmail author of review
+   * @param stars rating in stars
+   * @param dateReviewed the date of review
+   * @param comments comments left on review
+   * @return the saved MenuItemReview
+   */
+  @Operation(summary = "Create a new menuitemreview")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public MenuItemReview postMenuItemReviews(
+      @Parameter(name = "itemId") @RequestParam long itemId,
+      @Parameter(name = "reviewerEmail") @RequestParam String reviewerEmail,
+      @Parameter(name = "stars") @RequestParam int stars,
+      @Parameter(
+              name = "dateReviewed",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("dateReviewed")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateReviewed,
+      @Parameter(name = "comments") @RequestParam String comments)
+      throws JsonProcessingException {
+
+    // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    // See: https://www.baeldung.com/spring-date-parameters
+
+    log.info("dateReviwed={}", dateReviewed);
+
+    MenuItemReview menuItemReview = new MenuItemReview();
+    menuItemReview.setItemId(itemId);
+    menuItemReview.setReviewerEmail(reviewerEmail);
+    menuItemReview.setStars(stars);
+    menuItemReview.setDateReviewed(dateReviewed);
+    menuItemReview.setComments(comments);
+
+    MenuItemReview savedMenuItemReview = menuItemReviewRepository.save(menuItemReview);
+    return savedMenuItemReview;
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,0 +1,166 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = MenuItemReviewController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewControllerTests extends ControllerTestCase {
+
+  @MockitoBean MenuItemReviewRepository menuItemReviewRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/menuitemreviews/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/menuitemreviews/all")).andExpect(status().is(200)); // logged
+  }
+
+  /*
+    private long itemId;
+    private String reviewerEmail;
+    private int stars;
+    private LocalDateTime dateReviewed;
+    private String comments;
+  */
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/menuitemreviews/post")
+                .param("itemId", "7")
+                .param("reviewerEmail", "who@gmail.com")
+                .param("stars", "5")
+                .param("dateReviewed", "2022-01-03T00:00:00")
+                .param("comments", "very good")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/menuitemreviews/post")
+                .param("itemId", "7")
+                .param("reviewerEmail", "who@gmail.com")
+                .param("stars", "5")
+                .param("dateReviewed", "2022-01-03T00:00:00")
+                .param("comments", "very good")
+                .with(csrf()))
+        .andExpect(status().is(403)); // only admins can post
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview menuItemReview1 =
+        MenuItemReview.builder()
+            .itemId(7)
+            .reviewerEmail("joaquinwong@ucsb.edu")
+            .stars(4)
+            .dateReviewed(ldt1)
+            .comments("good")
+            .build();
+
+    LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+    MenuItemReview menuItemReview2 =
+        MenuItemReview.builder()
+            .itemId(8)
+            .reviewerEmail("jimjones@ucsb.edu")
+            .stars(2)
+            .dateReviewed(ldt2)
+            .comments("bad")
+            .build();
+
+    ArrayList<MenuItemReview> expectedMenuItemReviews = new ArrayList<>();
+    expectedMenuItemReviews.addAll(Arrays.asList(menuItemReview1, menuItemReview2));
+
+    when(menuItemReviewRepository.findAll()).thenReturn(expectedMenuItemReviews);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/menuitemreviews/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
+
+    verify(menuItemReviewRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedMenuItemReviews);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview menuItemReview1 =
+        MenuItemReview.builder()
+            .itemId(7)
+            .reviewerEmail("joaquinwong@ucsb.edu")
+            .stars(4)
+            .dateReviewed(ldt1)
+            .comments("good")
+            .build();
+
+    when(menuItemReviewRepository.save(eq(menuItemReview1))).thenReturn(menuItemReview1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/menuitemreviews/post")
+                    .param("itemId", "7")
+                    .param("reviewerEmail", "joaquinwong@ucsb.edu")
+                    .param("stars", "4")
+                    .param("dateReviewed", "2022-01-03T00:00:00")
+                    .param("comments", "good")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).save(menuItemReview1);
+    String expectedJson = mapper.writeValueAsString(menuItemReview1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
Closes #27 

Created MenuItemReviewController.java file with code for a GET /api/MenuItemReview/all endpoint and a POST /api/MenuItemReview/post endpoint. Endpoints work as expected in Swagger-UI(Both in localhost and dokku)
<img width="2174" height="1374" alt="image" src="https://github.com/user-attachments/assets/2c8a3440-bb4b-4dfe-9660-7d262f04f100" />

<img width="2160" height="1604" alt="image" src="https://github.com/user-attachments/assets/ae36310c-71cc-4cd7-9b6f-4cc268342260" />

100% coverage in jacoco
<img width="2186" height="604" alt="image" src="https://github.com/user-attachments/assets/f1aa59d1-272c-4467-8a17-87ff5b84dbea" />

100% coverage in pitest
<img width="1760" height="1086" alt="image" src="https://github.com/user-attachments/assets/c84c3518-d7b3-4d90-b82a-447778f714e9" />

