### PR TITLE
Add GET (show) endpoint for a single record in UCSBDiningCommonsMenuItem table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,67 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for UCSBDiningCommonsMenuItem */
+@Tag(name = "UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/ucsbdiningcommonsmenuitem")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemController extends ApiController {
+
+  @Autowired UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+  /**
+   * List all UCSB Dining Commons Menu Items
+   *
+   * @return an iterable of UCSBDiningCommonsMenuItem
+   */
+  @Operation(summary = "List all ucsb dining commons menu items")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItems() {
+    Iterable<UCSBDiningCommonsMenuItem> items = ucsbDiningCommonsMenuItemRepository.findAll();
+    return items;
+  }
+
+  /**
+   * Create a new ucsb dining commons menu item
+   *
+   * @param diningCommonsCode the dining commons code
+   * @param name the name of the item
+   * @param station the station
+   * @return the saved ucsb dining commons menu item
+   */
+  @Operation(summary = "Create a new dining commons menu item")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
+      @Parameter(name = "diningCommonsCode") @RequestParam String diningCommonsCode,
+      @Parameter(name = "name") @RequestParam String name,
+      @Parameter(name = "station") @RequestParam String station)
+      throws JsonProcessingException {
+
+    UCSBDiningCommonsMenuItem ucsbMenuItem = new UCSBDiningCommonsMenuItem();
+    ucsbMenuItem.setDiningCommonsCode(diningCommonsCode);
+    ucsbMenuItem.setName(name);
+    ucsbMenuItem.setStation(station);
+
+    UCSBDiningCommonsMenuItem savedUcsbMenuItem =
+        ucsbDiningCommonsMenuItemRepository.save(ucsbMenuItem);
+
+    return savedUcsbMenuItem;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.example.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -63,5 +64,23 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
         ucsbDiningCommonsMenuItemRepository.save(ucsbMenuItem);
 
     return savedUcsbMenuItem;
+  }
+
+  /**
+   * Get a single menu item by id
+   *
+   * @param id the id of the menuitem
+   * @return a UCSBDiningCommonsMenuItem
+   */
+  @Operation(summary = "Get a single dining commons menu item")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public UCSBDiningCommonsMenuItem getById(@Parameter(name = "id") @RequestParam Long id) {
+    UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem =
+        ucsbDiningCommonsMenuItemRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+    return ucsbDiningCommonsMenuItem;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -11,4 +11,4 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RepositoryRestResource(exported = false)
 public interface UCSBDiningCommonsMenuItemRepository
-    extends CrudRepository<UCSBDiningCommonsMenuItem, String> {}
+    extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -57,6 +57,56 @@
           }
         ]
       }
+    },
+    {
+      "changeSet": {
+        "id": "UCSBDiningCommonsMenuItem-2",
+        "author": "rohannihalani",
+        "comment": "Recreate with autoIncrement on ID; original changeset omitted it so inserts via @GeneratedValue(IDENTITY) failed.",
+        "changes": [
+          {
+            "dropTable": {
+              "tableName": "UCSBDININGCOMMONSMENUITEM"
+            }
+          },
+          {
+            "createTable": {
+              "tableName": "UCSBDININGCOMMONSMENUITEM",
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "UCSBDININGCOMMONSMENUITEMS_PK"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DINING_COMMONS_CODE",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "NAME",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "STATION",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,190 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
+  @MockitoBean UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/ucsbdiningcommonsmenuitem/post
+  // (Perhaps should also have these for put and delete)
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/ucsbdiningcommonsmenuitem/post")
+                .param("name", "spaghetti")
+                .param("diningCommonsCode", "carillo")
+                .param("station", "pasta")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/ucsbdiningcommonsmenuitem/post")
+                .param("name", "spaghetti")
+                .param("diningCommonsCode", "carillo")
+                .param("station", "pasta")
+                .with(csrf()))
+        .andExpect(status().is(403)); // only admins can post
+  }
+
+  // // Tests with mocks for database actions
+
+  // @WithMockUser(roles = {"USER"})
+  // @Test
+  // public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+  //
+  //
+  //   UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem =
+  //       UCSBDiningCommonsMenuItem.builder()
+  //           .name("spaghetti")
+  //           .diningCommonsCode("carillo")
+  //           .station("pasta")
+  //           .build();
+  //
+  //
+  // when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbDiningCommonsMenuItem));
+  //
+  //   // act
+  //   MvcResult response =
+  //       mockMvc
+  //           .perform(get("/api/ucsbdiningcommonsmenuitem").param("id", "7"))
+  //           .andExpect(status().isOk())
+  //           .andReturn();
+  //
+  //   // assert
+  //
+  //   verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+  //   String expectedJson = mapper.writeValueAsString(ucsbDiningCommonsMenuItem);
+  //   String responseString = response.getResponse().getContentAsString();
+  //
+  //   assertEquals(expectedJson, responseString);
+  // }
+
+  // @WithMockUser(roles = {"USER"})
+  // @Test
+  // public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws
+  // Exception {
+  //
+  //   // arrange
+  //
+  //   when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
+  //
+  //   // act
+  //   MvcResult response =
+  //       mockMvc
+  //           .perform(get("/api/ucsbdiningcommonsmenuitem").param("id", "7"))
+  //           .andExpect(status().isNotFound())
+  //           .andReturn();
+  //
+  //   // assert
+  //
+  //   verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+  //   Map<String, Object> json = responseToJson(response);
+  //   assertEquals("EntityNotFoundException", json.get("type"));
+  //   assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
+  // }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_ucsbdiningcommonsmenuitems() throws Exception {
+
+    UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 =
+        UCSBDiningCommonsMenuItem.builder()
+            .name("tacos")
+            .diningCommonsCode("dlg")
+            .station("mexican")
+            .build();
+
+    UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem2 =
+        UCSBDiningCommonsMenuItem.builder()
+            .name("pasta")
+            .diningCommonsCode("ortega")
+            .station("italian")
+            .build();
+
+    ArrayList<UCSBDiningCommonsMenuItem> expectedItems = new ArrayList<>();
+    expectedItems.addAll(Arrays.asList(ucsbDiningCommonsMenuItem1, ucsbDiningCommonsMenuItem2));
+
+    when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedItems);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedItems);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_ucsbdiningcommonsmenuitem() throws Exception {
+    // arrange
+
+    UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 =
+        UCSBDiningCommonsMenuItem.builder()
+            .name("tacos")
+            .diningCommonsCode("dlg")
+            .station("pasta")
+            .build();
+
+    when(ucsbDiningCommonsMenuItemRepository.save(eq(ucsbDiningCommonsMenuItem1)))
+        .thenReturn(ucsbDiningCommonsMenuItem1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/ucsbdiningcommonsmenuitem/post")
+                    .param("name", "tacos")
+                    .param("diningCommonsCode", "dlg")
+                    .param("station", "pasta")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(ucsbDiningCommonsMenuItem1);
+    String expectedJson = mapper.writeValueAsString(ucsbDiningCommonsMenuItem1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -16,6 +16,8 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -59,62 +61,60 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
         .andExpect(status().is(403)); // only admins can post
   }
 
-  // // Tests with mocks for database actions
+  // Tests with mocks for database actions
 
-  // @WithMockUser(roles = {"USER"})
-  // @Test
-  // public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
-  //
-  //
-  //   UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem =
-  //       UCSBDiningCommonsMenuItem.builder()
-  //           .name("spaghetti")
-  //           .diningCommonsCode("carillo")
-  //           .station("pasta")
-  //           .build();
-  //
-  //
-  // when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbDiningCommonsMenuItem));
-  //
-  //   // act
-  //   MvcResult response =
-  //       mockMvc
-  //           .perform(get("/api/ucsbdiningcommonsmenuitem").param("id", "7"))
-  //           .andExpect(status().isOk())
-  //           .andReturn();
-  //
-  //   // assert
-  //
-  //   verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
-  //   String expectedJson = mapper.writeValueAsString(ucsbDiningCommonsMenuItem);
-  //   String responseString = response.getResponse().getContentAsString();
-  //
-  //   assertEquals(expectedJson, responseString);
-  // }
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
 
-  // @WithMockUser(roles = {"USER"})
-  // @Test
-  // public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws
-  // Exception {
-  //
-  //   // arrange
-  //
-  //   when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
-  //
-  //   // act
-  //   MvcResult response =
-  //       mockMvc
-  //           .perform(get("/api/ucsbdiningcommonsmenuitem").param("id", "7"))
-  //           .andExpect(status().isNotFound())
-  //           .andReturn();
-  //
-  //   // assert
-  //
-  //   verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
-  //   Map<String, Object> json = responseToJson(response);
-  //   assertEquals("EntityNotFoundException", json.get("type"));
-  //   assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
-  // }
+    UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .name("spaghetti")
+            .diningCommonsCode("carillo")
+            .station("pasta")
+            .build();
+
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L)))
+        .thenReturn(Optional.of(ucsbDiningCommonsMenuItem));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsbdiningcommonsmenuitem").param("id", "7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+    String expectedJson = mapper.writeValueAsString(ucsbDiningCommonsMenuItem);
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+    // arrange
+
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsbdiningcommonsmenuitem").param("id", "7"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
+  }
 
   @WithMockUser(roles = {"USER"})
   @Test


### PR DESCRIPTION
Closes #10 

All tests passing, added an endpoint for getting menu items via index. Works locally and has full coverage. Merge PR #52 first before merging this one.

<img width="1119" height="270" alt="Screenshot 2026-04-28 at 10 39 30 AM" src="https://github.com/user-attachments/assets/2c09c659-8f12-46d4-8a73-fcd771ad5b93" />
<img width="1039" height="579" alt="Screenshot 2026-04-28 at 10 45 11 AM" src="https://github.com/user-attachments/assets/39507de9-4399-42c9-a774-6235e1e8e145" />
