### PR TITLE
Added PUT enpoint for MenuItemReview Table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +15,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -97,6 +100,37 @@ public class MenuItemReviewController extends ApiController {
         menuItemReviewRepository
             .findById(id)
             .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    return menuItemReview;
+  }
+
+  /**
+   * Update a single menu item review
+   *
+   * @param id id of the menu item review to update
+   * @param incoming the new menu item review
+   * @return the updated MenuItemReview object
+   */
+  @Operation(summary = "Update a single menuitemreview")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public MenuItemReview updateMenuItemReview(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid MenuItemReview incoming) {
+
+    MenuItemReview menuItemReview =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    // There would also be an incoming.getId, since the RequestBody includes that, but we use the
+    // Long id parameter instead
+    menuItemReview.setItemId(incoming.getItemId());
+    menuItemReview.setReviewerEmail(incoming.getReviewerEmail());
+    menuItemReview.setStars(incoming.getStars());
+    menuItemReview.setDateReviewed(incoming.getDateReviewed());
+    menuItemReview.setComments(incoming.getComments());
+
+    menuItemReviewRepository.save(menuItemReview);
 
     return menuItemReview;
   }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -85,7 +86,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = {"USER"})
   @Test
-  public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+  public void logged_in_user_can_get_all_menuitemreviews() throws Exception {
 
     // arrange
     LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
@@ -129,7 +130,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
-  public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+  public void an_admin_user_can_post_a_new_menuitemreview() throws Exception {
     // arrange
 
     LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
@@ -229,5 +230,97 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
     assertEquals("MenuItemReview with id 7 not found", json.get("message"));
+  }
+
+  // PUT TESTS
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_menuitemreview() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+    MenuItemReview menuItemReviewOrig =
+        MenuItemReview.builder()
+            .itemId(7)
+            .reviewerEmail("joaquinwong@ucsb.edu")
+            .stars(4)
+            .dateReviewed(ldt1)
+            .comments("good")
+            .build();
+
+    MenuItemReview menuItemReviewEdited =
+        MenuItemReview.builder()
+            .itemId(8)
+            .reviewerEmail("put@ucsb.edu")
+            .stars(2)
+            .dateReviewed(ldt2)
+            .comments("bad")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(menuItemReviewEdited);
+
+    when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.of(menuItemReviewOrig));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/menuitemreviews")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(67L);
+    verify(menuItemReviewRepository, times(1))
+        .save(menuItemReviewEdited); // should be saved with correct user
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_menuitemreview_that_does_not_exist() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview menuItemReviewEdited =
+        MenuItemReview.builder()
+            .itemId(7)
+            .reviewerEmail("joaquinwong@ucsb.edu")
+            .stars(4)
+            .dateReviewed(ldt1)
+            .comments("good")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(menuItemReviewEdited);
+
+    when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/menuitemreviews")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(67L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("MenuItemReview with id 67 not found", json.get("message"));
   }
 }


### PR DESCRIPTION
Closes #29 
Added PUT method to MenuItemReviewController. It works on Swagger-UI(localhost and dokku)
<img width="2696" height="1344" alt="image" src="https://github.com/user-attachments/assets/df402159-c277-4e41-b68f-6823e4d14393" />

100% Coverage on Jacoco
<img width="2172" height="514" alt="image" src="https://github.com/user-attachments/assets/69e2d06c-bef6-4c11-b24f-e965f175af27" />

100% Coverage on Pitest
<img width="1712" height="676" alt="image" src="https://github.com/user-attachments/assets/f18285fb-6d63-494f-a15b-c088c7493317" />
