### PR TITLE
Add controller for UCSB Organization and tested with 100% coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,11 +181,6 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M5</version>
-        <configuration>
-          <!-- Activate the use of TCP to transmit events to the plugin -->
-          <forkNode
-            implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
-        </configuration>
       </plugin>
 
       <!-- Gives us: mvn spring-boot:run -->

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,67 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for UCSBOrganization. */
+@Tag(name = "UCSBOrganization")
+@RequestMapping("/api/ucsborganization")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController {
+
+  @Autowired UCSBOrganizationRepository ucsbOrganizationRepository;
+
+  /**
+   * List all UCSB organizations.
+   *
+   * @return an iterable of UCSBOrganization
+   */
+  @Operation(summary = "List all ucsb organizations")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<UCSBOrganization> allUCSBOrganizations() {
+    Iterable<UCSBOrganization> organizations = ucsbOrganizationRepository.findAll();
+    return organizations;
+  }
+
+  /**
+   * Create a new organization.
+   *
+   * @param orgCode the organization code
+   * @param orgTranslationShort short organization name
+   * @param orgTranslation full organization name
+   * @param inactive whether the organization is inactive
+   * @return the saved organization
+   */
+  @Operation(summary = "Create a new organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public UCSBOrganization postUCSBOrganization(
+      @Parameter(name = "orgCode") @RequestParam String orgCode,
+      @Parameter(name = "orgTranslationShort") @RequestParam String orgTranslationShort,
+      @Parameter(name = "orgTranslation") @RequestParam String orgTranslation,
+      @Parameter(name = "inactive") @RequestParam boolean inactive) {
+
+    UCSBOrganization organization = new UCSBOrganization();
+    organization.setOrgCode(orgCode);
+    organization.setOrgTranslationShort(orgTranslationShort);
+    organization.setOrgTranslation(orgTranslation);
+    organization.setInactive(inactive);
+
+    UCSBOrganization savedOrganization = ucsbOrganizationRepository.save(organization);
+
+    return savedOrganization;
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,141 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+
+  @MockitoBean UCSBOrganizationRepository ucsbOrganizationRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/ucsborganization/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/ucsborganization/all")).andExpect(status().is(200));
+  }
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/ucsborganization/post")
+                .param("orgCode", "ACM")
+                .param("orgTranslationShort", "ACM")
+                .param("orgTranslation", "Association for Computing Machinery")
+                .param("inactive", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/ucsborganization/post")
+                .param("orgCode", "ACM")
+                .param("orgTranslationShort", "ACM")
+                .param("orgTranslation", "Association for Computing Machinery")
+                .param("inactive", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_organizations() throws Exception {
+    // arrange
+    UCSBOrganization acm =
+        UCSBOrganization.builder()
+            .orgCode("ACM")
+            .orgTranslationShort("ACM")
+            .orgTranslation("Association for Computing Machinery")
+            .inactive(false)
+            .build();
+
+    UCSBOrganization ieee =
+        UCSBOrganization.builder()
+            .orgCode("IEEE")
+            .orgTranslationShort("IEEE")
+            .orgTranslation("Institute of Electrical and Electronics Engineers")
+            .inactive(false)
+            .build();
+
+    ArrayList<UCSBOrganization> expectedOrganizations = new ArrayList<>();
+    expectedOrganizations.addAll(Arrays.asList(acm, ieee));
+
+    when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganizations);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/ucsborganization/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
+    verify(ucsbOrganizationRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedOrganizations);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_organization() throws Exception {
+    // arrange
+    UCSBOrganization acm =
+        UCSBOrganization.builder()
+            .orgCode("ACM")
+            .orgTranslationShort("ACM")
+            .orgTranslation("Association for Computing Machinery")
+            .inactive(true)
+            .build();
+
+    when(ucsbOrganizationRepository.save(acm)).thenReturn(acm);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/ucsborganization/post")
+                    .param("orgCode", "ACM")
+                    .param("orgTranslationShort", "ACM")
+                    .param("orgTranslation", "Association for Computing Machinery")
+                    .param("inactive", "true")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbOrganizationRepository, times(1)).save(acm);
+    String expectedJson = mapper.writeValueAsString(acm);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
This PR adds backend GET-all and POST support for UCSB Organizations so team members can create and list organizations through the API and Swagger.

This closes Issue #15. 

## What changed
- added `UCSBOrganizationController.java`
- added `GET /api/ucsborganization/all`
- added `POST /api/ucsborganization/post`
- added `UCSBOrganizationControllerTests.java`
- added auth tests and mocked controller tests for GET-all and POST (with 100% coverage on jacoco)

## Why
This is the next backend step for UCSB Organizations after creating the entity, repository, and migration. It enables creating organization records and listing all records.

## Testing

Locally:
Run:
mvn test jacoco:report
mvn test pitest:mutationCoverage
and check UCSBOrganization

On Dokkku:
Sync the branch to the personal Dokku dev app
Rebuild the app
Verify the GET and POST endpoints on the deployed app
