### PR TITLE
Add Get by id for UCSB Organization

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -34,6 +35,24 @@ public class UCSBOrganizationController extends ApiController {
   public Iterable<UCSBOrganization> allUCSBOrganizations() {
     Iterable<UCSBOrganization> organizations = ucsbOrganizationRepository.findAll();
     return organizations;
+  }
+
+  /**
+   * This method returns a single organization.
+   *
+   * @param orgCode orgCode of the organization
+   * @return a single organization
+   */
+  @Operation(summary = "Get a single organization")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public UCSBOrganization getById(@Parameter(name = "orgCode") @RequestParam String orgCode) {
+    UCSBOrganization organization =
+        ucsbOrganizationRepository
+            .findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+    return organization;
   }
 
   /**

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -16,6 +17,8 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -137,5 +140,54 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(acm);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/ucsborganization").param("orgCode", "ACM"))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+    UCSBOrganization acm =
+        UCSBOrganization.builder()
+            .orgCode("ACM")
+            .orgTranslationShort("ACM")
+            .orgTranslation("Association for Computing Machinery")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById(eq("ACM"))).thenReturn(Optional.of(acm));
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsborganization").param("orgCode", "ACM"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("ACM"));
+    String expectedJson = mapper.writeValueAsString(acm);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+    when(ucsbOrganizationRepository.findById(eq("NOPE"))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsborganization").param("orgCode", "NOPE"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("NOPE"));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBOrganization with id NOPE not found", json.get("message"));
   }
 }


### PR DESCRIPTION
This PR adds backend GET-by-id support for UCSB Organizations so team members can find a given organization by its orgCode through the API and Swagger.

## What changed

- added 'GET /api/ucsborganization/ in `UCSBOrganizationController.java`
- added auth tests and mocked controller tests for GET-all and POST (with 100% jacoco coverage)

## Why
This enables finding / looking up organizations by their orgCode. 

## Testing

### Local
Locally:
Run:
mvn test jacoco:report
mvn test pitest:mutationCoverage
and check GET /api/UCSBOrganization

On Dokkku:
Sync the branch to the personal Dokku dev app
Rebuild the app
Verify the GET by id endpoint on the deployed app


