### PR TITLE
Build PUT for UCSBOrganization

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -34,6 +35,24 @@ public class UCSBOrganizationController extends ApiController {
   public Iterable<UCSBOrganization> allUCSBOrganizations() {
     Iterable<UCSBOrganization> organizations = ucsbOrganizationRepository.findAll();
     return organizations;
+  }
+
+  /**
+   * This method returns a single organization.
+   *
+   * @param orgCode orgCode of the organization
+   * @return a single organization
+   */
+  @Operation(summary = "Get a single organization")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public UCSBOrganization getById(@Parameter(name = "orgCode") @RequestParam String orgCode) {
+    UCSBOrganization organization =
+        ucsbOrganizationRepository
+            .findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+    return organization;
   }
 
   /**

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -6,11 +6,14 @@ import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -82,5 +85,34 @@ public class UCSBOrganizationController extends ApiController {
     UCSBOrganization savedOrganization = ucsbOrganizationRepository.save(organization);
 
     return savedOrganization;
+  }
+
+  /**
+   * Update a single organization. Accessible only to users with the role "ROLE_ADMIN".
+   *
+   * @param orgCode orgCode of the organization
+   * @param incoming the new organization contents
+   * @return the updated organization object
+   */
+  @Operation(summary = "Update a single organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public UCSBOrganization updateOrganization(
+      @Parameter(name = "orgCode") @RequestParam String orgCode,
+      @RequestBody @Valid UCSBOrganization incoming) {
+
+    UCSBOrganization organization =
+        ucsbOrganizationRepository
+            .findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+    organization.setOrgCode(incoming.getOrgCode());
+    organization.setOrgTranslationShort(incoming.getOrgTranslationShort());
+    organization.setOrgTranslation(incoming.getOrgTranslation());
+    organization.setInactive(incoming.getInactive());
+
+    ucsbOrganizationRepository.save(organization);
+
+    return organization;
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edu.ucsb.cs156.example.ControllerTestCase;
@@ -22,6 +23,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -50,8 +52,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     mockMvc
         .perform(
             post("/api/ucsborganization/post")
-                .param("orgCode", "ACM")
-                .param("orgTranslationShort", "ACM")
+                .param("orgCode", "acm")
+                .param("orgTranslationShort", "acm")
                 .param("orgTranslation", "Association for Computing Machinery")
                 .param("inactive", "false")
                 .with(csrf()))
@@ -64,8 +66,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     mockMvc
         .perform(
             post("/api/ucsborganization/post")
-                .param("orgCode", "ACM")
-                .param("orgTranslationShort", "ACM")
+                .param("orgCode", "acm")
+                .param("orgTranslationShort", "acm")
                 .param("orgTranslation", "Association for Computing Machinery")
                 .param("inactive", "false")
                 .with(csrf()))
@@ -78,8 +80,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     // arrange
     UCSBOrganization acm =
         UCSBOrganization.builder()
-            .orgCode("ACM")
-            .orgTranslationShort("ACM")
+            .orgCode("acm")
+            .orgTranslationShort("acm")
             .orgTranslation("Association for Computing Machinery")
             .inactive(false)
             .build();
@@ -114,8 +116,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     // arrange
     UCSBOrganization acm =
         UCSBOrganization.builder()
-            .orgCode("ACM")
-            .orgTranslationShort("ACM")
+            .orgCode("acm")
+            .orgTranslationShort("acm")
             .orgTranslation("Association for Computing Machinery")
             .inactive(true)
             .build();
@@ -127,8 +129,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
         mockMvc
             .perform(
                 post("/api/ucsborganization/post")
-                    .param("orgCode", "ACM")
-                    .param("orgTranslationShort", "ACM")
+                    .param("orgCode", "acm")
+                    .param("orgTranslationShort", "acm")
                     .param("orgTranslation", "Association for Computing Machinery")
                     .param("inactive", "true")
                     .with(csrf()))
@@ -145,7 +147,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   @Test
   public void logged_out_users_cannot_get_by_id() throws Exception {
     mockMvc
-        .perform(get("/api/ucsborganization").param("orgCode", "ACM"))
+        .perform(get("/api/ucsborganization").param("orgCode", "acm"))
         .andExpect(status().is(403));
   }
 
@@ -154,21 +156,21 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
     UCSBOrganization acm =
         UCSBOrganization.builder()
-            .orgCode("ACM")
-            .orgTranslationShort("ACM")
+            .orgCode("acm")
+            .orgTranslationShort("acm")
             .orgTranslation("Association for Computing Machinery")
             .inactive(false)
             .build();
 
-    when(ucsbOrganizationRepository.findById(eq("ACM"))).thenReturn(Optional.of(acm));
+    when(ucsbOrganizationRepository.findById(eq("acm"))).thenReturn(Optional.of(acm));
 
     MvcResult response =
         mockMvc
-            .perform(get("/api/ucsborganization").param("orgCode", "ACM"))
+            .perform(get("/api/ucsborganization").param("orgCode", "acm"))
             .andExpect(status().isOk())
             .andReturn();
 
-    verify(ucsbOrganizationRepository, times(1)).findById(eq("ACM"));
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("acm"));
     String expectedJson = mapper.writeValueAsString(acm);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
@@ -189,5 +191,94 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
     assertEquals("UCSBOrganization with id NOPE not found", json.get("message"));
+  }
+
+  // TESTING FOR PUT
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_organization() throws Exception {
+    // arrange
+
+    UCSBOrganization acmOrig =
+        UCSBOrganization.builder()
+            .orgCode("acm")
+            .orgTranslationShort("acm")
+            .orgTranslation("Association of Computing Machinery")
+            .inactive(false)
+            .build();
+
+    //             organization.setOrgCode(incoming.getOrgCode());
+    // organization.setOrgTranslationShort(incoming.getOrgTranslationShort());
+    // organization.setOrgTranslation(incoming.getOrgTranslation());
+    // organization.setInactive(incoming.getInactive());
+
+    UCSBOrganization acmEdited =
+        UCSBOrganization.builder()
+            .orgCode("acm")
+            .orgTranslationShort("acm organization")
+            .orgTranslation("Association of Computing Machinery Industry")
+            .inactive(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(acmEdited);
+
+    when(ucsbOrganizationRepository.findById(eq("acm"))).thenReturn(Optional.of(acmOrig));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/ucsborganization")
+                    .param("orgCode", "acm")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbOrganizationRepository, times(1)).findById("acm");
+    verify(ucsbOrganizationRepository, times(1))
+        .save(acmEdited); // should be saved with updated info
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_organization_that_does_not_exist() throws Exception {
+    // arrange
+
+    UCSBOrganization editedorganization =
+        UCSBOrganization.builder()
+            .orgCode("sbhacks")
+            .orgTranslationShort("SHhacks")
+            .orgTranslation("Santa Barbara Hacks")
+            .inactive(false)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(editedorganization);
+
+    when(ucsbOrganizationRepository.findById(eq("sbhacks"))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/ucsborganization")
+                    .param("orgCode", "sbhacks")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(ucsbOrganizationRepository, times(1)).findById("sbhacks");
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("UCSBOrganization with id sbhacks not found", json.get("message"));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -16,6 +17,8 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -137,5 +140,54 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(acm);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/ucsborganization").param("orgCode", "ACM"))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+    UCSBOrganization acm =
+        UCSBOrganization.builder()
+            .orgCode("ACM")
+            .orgTranslationShort("ACM")
+            .orgTranslation("Association for Computing Machinery")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById(eq("ACM"))).thenReturn(Optional.of(acm));
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsborganization").param("orgCode", "ACM"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("ACM"));
+    String expectedJson = mapper.writeValueAsString(acm);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+    when(ucsbOrganizationRepository.findById(eq("NOPE"))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsborganization").param("orgCode", "NOPE"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("NOPE"));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBOrganization with id NOPE not found", json.get("message"));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -215,7 +215,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
     UCSBOrganization acmEdited =
         UCSBOrganization.builder()
-            .orgCode("acm")
+            .orgCode("acm-updated")
             .orgTranslationShort("acm organization")
             .orgTranslation("Association of Computing Machinery Industry")
             .inactive(true)


### PR DESCRIPTION
This PR adds backend GET-all and POST support for UCSB Organizations so team members can create and list organizations through the API and Swagger.
This closes Issue #17


## What changed
* added PUT /api/ucsborganization
* added auth tests and mocked controller tests for PUT (with 100% coverage on jacoco)
* 
Why
This allows for adding Organizations and PUT support.

Testing
Locally: Run: 
mvn test 
jacoco:report mvn test 
pitest:mutationCoverage 
and check UCSBOrganization

On Dokkku: 
Sync the branch to the personal Dokku dev app 
Rebuild the app 
Verify the PUT endpoint on the deployed app