### PR TITLE
as - create get and post for rec

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -1,0 +1,78 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for RecommendationRequests */
+@Tag(name = "RecommendationRequests")
+@RequestMapping("/api/recommendationrequests")
+@RestController
+@Slf4j
+public class RecommendationRequestController extends ApiController {
+
+  @Autowired RecommendationRequestRepository recommendationRequestRepository;
+
+  /**
+   * List all recommendation requests
+   *
+   * @return an iterable of RecommendationRequest
+   */
+  @Operation(summary = "List all recommendation requests")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<RecommendationRequest> allRecommendationRequests() {
+    Iterable<RecommendationRequest> requests = recommendationRequestRepository.findAll();
+    return requests;
+  }
+
+  /**
+   * Create a new recommendation request
+   *
+   * @return the saved RecommendationRequest
+   */
+  @Operation(summary = "Create a new recommendation request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public RecommendationRequest postRecommendationRequest(
+      @Parameter(name = "requesterEmail") @RequestParam String requesterEmail,
+      @Parameter(name = "professorEmail") @RequestParam String professorEmail,
+      @Parameter(name = "explanation") @RequestParam String explanation,
+      @Parameter(name = "dateRequested")
+          @RequestParam
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateRequested,
+      @Parameter(name = "dateNeeded")
+          @RequestParam
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateNeeded,
+      @Parameter(name = "done") @RequestParam boolean done)
+      throws JsonProcessingException {
+
+    log.info("dateRequested={}", dateRequested);
+
+    RecommendationRequest request = new RecommendationRequest();
+    request.setRequesterEmail(requesterEmail);
+    request.setProfessorEmail(professorEmail);
+    request.setExplanation(explanation);
+    request.setDateRequested(dateRequested);
+    request.setDateNeeded(dateNeeded);
+    request.setDone(done);
+
+    RecommendationRequest savedRequest = recommendationRequestRepository.save(request);
+    return savedRequest;
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -1,0 +1,214 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = RecommendationRequestController.class)
+@Import(TestConfig.class)
+public class RecommendationRequestControllerTests extends ControllerTestCase {
+
+  @MockitoBean RecommendationRequestRepository recommendationRequestRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for GET /api/recommendationrequests/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/recommendationrequests/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/recommendationrequests/all")).andExpect(status().is(200));
+  }
+
+  // Authorization tests for POST /api/recommendationrequests/post
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/recommendationrequests/post")
+                .param("requesterEmail", "cgaucho@ucsb.edu")
+                .param("professorEmail", "phtcon@ucsb.edu")
+                .param("explanation", "BS/MS program")
+                .param("dateRequested", "2022-04-20T00:00:00")
+                .param("dateNeeded", "2022-05-01T00:00:00")
+                .param("done", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/recommendationrequests/post")
+                .param("requesterEmail", "cgaucho@ucsb.edu")
+                .param("professorEmail", "phtcon@ucsb.edu")
+                .param("explanation", "BS/MS program")
+                .param("dateRequested", "2022-04-20T00:00:00")
+                .param("dateNeeded", "2022-05-01T00:00:00")
+                .param("done", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_recommendation_requests() throws Exception {
+
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T00:00:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2022-05-01T00:00:00");
+
+    RecommendationRequest req1 =
+        RecommendationRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .professorEmail("phtcon@ucsb.edu")
+            .explanation("BS/MS program")
+            .dateRequested(ldt1)
+            .dateNeeded(ldt2)
+            .done(false)
+            .build();
+
+    LocalDateTime ldt3 = LocalDateTime.parse("2022-05-20T00:00:00");
+    LocalDateTime ldt4 = LocalDateTime.parse("2022-11-15T00:00:00");
+
+    RecommendationRequest req2 =
+        RecommendationRequest.builder()
+            .requesterEmail("ldelplaya@ucsb.edu")
+            .professorEmail("richert@ucsb.edu")
+            .explanation("PhD CS Stanford")
+            .dateRequested(ldt3)
+            .dateNeeded(ldt4)
+            .done(false)
+            .build();
+
+    ArrayList<RecommendationRequest> expectedRequests = new ArrayList<>();
+    expectedRequests.addAll(Arrays.asList(req1, req2));
+
+    when(recommendationRequestRepository.findAll()).thenReturn(expectedRequests);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/recommendationrequests/all"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(recommendationRequestRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedRequests);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_recommendation_request() throws Exception {
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T00:00:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2022-05-01T00:00:00");
+
+    RecommendationRequest req1 =
+        RecommendationRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .professorEmail("phtcon@ucsb.edu")
+            .explanation("BS/MS program")
+            .dateRequested(ldt1)
+            .dateNeeded(ldt2)
+            .done(false)
+            .build();
+
+    when(recommendationRequestRepository.save(eq(req1))).thenReturn(req1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/recommendationrequests/post")
+                    .param("requesterEmail", "cgaucho@ucsb.edu")
+                    .param("professorEmail", "phtcon@ucsb.edu")
+                    .param("explanation", "BS/MS program")
+                    .param("dateRequested", "2022-04-20T00:00:00")
+                    .param("dateNeeded", "2022-05-01T00:00:00")
+                    .param("done", "false")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(recommendationRequestRepository, times(1)).save(req1);
+    String expectedJson = mapper.writeValueAsString(req1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_recommendation_request_done_true() throws Exception {
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T00:00:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2022-05-01T00:00:00");
+
+    RecommendationRequest req1 =
+        RecommendationRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .professorEmail("phtcon@ucsb.edu")
+            .explanation("BS/MS program")
+            .dateRequested(ldt1)
+            .dateNeeded(ldt2)
+            .done(true)
+            .build();
+
+    when(recommendationRequestRepository.save(eq(req1))).thenReturn(req1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/recommendationrequests/post")
+                    .param("requesterEmail", "cgaucho@ucsb.edu")
+                    .param("professorEmail", "phtcon@ucsb.edu")
+                    .param("explanation", "BS/MS program")
+                    .param("dateRequested", "2022-04-20T00:00:00")
+                    .param("dateNeeded", "2022-05-01T00:00:00")
+                    .param("done", "true")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(recommendationRequestRepository, times(1)).save(req1);
+    String expectedJson = mapper.writeValueAsString(req1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
Fixes #21 

# Acceptance Criteria:

- [ ] There is a controller file `RecommendationRequestController.java`
  in the expected directory.
- [ ] In `RecommendationRequestController.java` there is 
  code for a `GET /api/RecommendationRequest/all` endpoint 
  that returns a JSON list of all `RecommendationRequest`s in the database.
  (We sometimes call this an *index* action since it lists all
  items in the database.)
- [ ] In `RecommendationRequestController.java` there is 
  code for a `POST /api/RecommendationRequest/post` endpoint
  that can be used to create a new entry in the table. (This
  is a *create* action.)
- [ ] The Swagger-UI endpoints for these are well documented so that
  any member of the team can understand what they are for and
  how to use them.
- [ ] The `POST` endpoint works as expected, in the sense that new
  records can be added to the database (on localhost).
- [ ] The `GET` endpoint works as expected, in the sense that the new
  records that are added show up (on localhost).
- [ ] The `GET` and `POST` endpoints work as expected when the 
  app is deployed to Dokku.
- [ ] There is full test coverage (Jacoco) for the methods in 
  `RecommendationRequestController.java`
- [ ] There is full mutation test coverage (Pitest) for the methods in
  `RecommendationRequestController.java`
